### PR TITLE
Add TypeConverterJsonConverterFactory to bridge [TypeConverter] types to STJ

### DIFF
--- a/src/Totem.Runtime/Hosting/JsonFormatOptionsSetup.cs
+++ b/src/Totem.Runtime/Hosting/JsonFormatOptionsSetup.cs
@@ -19,6 +19,7 @@ namespace Totem.Runtime.Hosting
       settings.DictionaryKeyPolicy = null;
 
       settings.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+      settings.Converters.Add(new TypeConverterJsonConverterFactory());
     }
 
     public void PostConfigure(string name, JsonFormatOptions options)

--- a/src/Totem.Runtime/Json/TypeConverterJsonConverterFactory.cs
+++ b/src/Totem.Runtime/Json/TypeConverterJsonConverterFactory.cs
@@ -1,0 +1,58 @@
+using System;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Totem.Runtime.Json
+{
+  /// <summary>
+  /// Bridges <see cref="System.ComponentModel.TypeConverter"/> to STJ, replicating
+  /// Newtonsoft's built-in behavior of serializing [TypeConverter] types as JSON strings
+  /// </summary>
+  public class TypeConverterJsonConverterFactory : JsonConverterFactory
+  {
+    public override bool CanConvert(Type typeToConvert)
+    {
+      var converter = TypeDescriptor.GetConverter(typeToConvert);
+
+      return converter.GetType() != typeof(TypeConverter)
+        && converter.CanConvertFrom(typeof(string))
+        && converter.CanConvertTo(typeof(string));
+    }
+
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+      var converterType = typeof(TypeConverterJsonConverter<>).MakeGenericType(typeToConvert);
+
+      return (JsonConverter)Activator.CreateInstance(converterType);
+    }
+
+    class TypeConverterJsonConverter<T> : JsonConverter<T>
+    {
+      readonly TypeConverter _converter = TypeDescriptor.GetConverter(typeof(T));
+
+      public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+      {
+        if(reader.TokenType == JsonTokenType.Null)
+        {
+          return default;
+        }
+
+        var text = reader.GetString();
+
+        return (T)_converter.ConvertFromInvariantString(text);
+      }
+
+      public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+      {
+        if(value is null)
+        {
+          writer.WriteNullValue();
+          return;
+        }
+
+        writer.WriteStringValue(_converter.ConvertToInvariantString(value));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

After the Newtonsoft → STJ migration, deserialization crashes for 20+ types (`TypeName`, `Id`, `FileLink`, `HttpLink`, etc.) that rely on `[TypeConverter]` + `TextConverter` for string-based serialization.

Newtonsoft auto-detected `[TypeConverter]` attributes and serialized/deserialized these types as JSON strings. STJ has no such built-in behavior, causing:
 - **Exceptions** for class types with private constructors (e.g. `TypeName`, `FileLink`)
 - **Silent data loss** for struct types like `Id` (defaults to `Unassigned` instead of crashing)

System.NotSupportedException: Deserialization of types without a parameterless constructor, a singular parameterized constructor, or a parameterized constructor annotated with 'JsonConstructorAttribute' is not supported. Type 'Totem.Reflection.TypeName'.

## Solution

Introduces `TypeConverterJsonConverterFactory`, a `JsonConverterFactory` that bridges `System.ComponentModel.TypeConverter` to STJ:

 - **`CanConvert`** — detects types with a non-default `TypeConverter` that supports string conversion
 - **`Read`** — `reader.GetString()` → `ConvertFromInvariantString()` → `T`
 - **`Write`** — `T` → `ConvertToInvariantString()` → `writer.WriteStringValue()`

Registered in `JsonFormatOptionsSetup.Configure()` after `JsonStringEnumConverter`, before the durable type converters in `PostConfigure()`. No conflicts — TypeConverter types are not durable, and durable types don't have TypeConverters.

## Affected Types

`TypeName`, `Id`, `FileLink`, `FolderLink`, `FileResource`, `FileName`, `FolderResource`, `HttpResource`, `HttpLink`, `HttpHost`, `HttpDomain`, `HttpQuery`, `HttpQueryPair`, `HttpAuthorization`, `MediaType`, `Sha1`, `Hex`, `LinkText`, and others with `TextConverter`-based `[TypeConverter]` attributes.

## Backward Compatibility

Full compatibility — EventStore data written by Newtonsoft stored these types as JSON strings. This converter reads and writes the same string format via the same `TypeConverter` code path.