### PR TITLE
Narrow TypeConverterJsonConverterFactory and add dictionary key support

### DIFF
--- a/src/Totem.Runtime/Json/TypeConverterJsonConverterFactory.cs
+++ b/src/Totem.Runtime/Json/TypeConverterJsonConverterFactory.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Totem.IO;
 
 namespace Totem.Runtime.Json
 {
@@ -13,11 +14,7 @@ namespace Totem.Runtime.Json
   {
     public override bool CanConvert(Type typeToConvert)
     {
-      var converter = TypeDescriptor.GetConverter(typeToConvert);
-
-      return converter.GetType() != typeof(TypeConverter)
-        && converter.CanConvertFrom(typeof(string))
-        && converter.CanConvertTo(typeof(string));
+      return TypeDescriptor.GetConverter(typeToConvert) is TextConverter;
     }
 
     public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)

--- a/src/Totem.Runtime/Json/TypeConverterJsonConverterFactory.cs
+++ b/src/Totem.Runtime/Json/TypeConverterJsonConverterFactory.cs
@@ -50,6 +50,20 @@ namespace Totem.Runtime.Json
 
         writer.WriteStringValue(_converter.ConvertToInvariantString(value));
       }
+
+      // Necessary to read Totem.Id as Dictionary Keys.
+      public override T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+      {
+        var text = reader.GetString();
+
+        return (T)_converter.ConvertFromInvariantString(text);
+      }
+
+      // Necessary to save Totem.Id as Dictionary Keys.
+      public override void WriteAsPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+      {
+        writer.WritePropertyName(_converter.ConvertToInvariantString(value));
+      }
     }
   }
 }

--- a/src/Totem.Timeline/Runtime/TimelineHost.cs
+++ b/src/Totem.Timeline/Runtime/TimelineHost.cs
@@ -62,8 +62,6 @@ namespace Totem.Timeline.Runtime
 
       _schedule.Resume(resumeInfo.Schedule);
 
-      Log.Info("Resume: yes");
-
       return resumeInfo.Subscription;
     }
 


### PR DESCRIPTION
## Problem

After merging `TypeConverterJsonConverterFactory` (#11), two issues blocked the `UpdateRegistry` endpoint in `ScanController`:

### 1. `CanConvert` was too broad — silent model binding failure

The factory's `CanConvert` matched every .NET type with a `TypeConverter` (`int`, `DateTime`, `bool`, `Guid`, etc.), not just Totem's `TextConverter` types. When STJ routed `SmartScanRecord.FileCount` (an `int`, JSON Number token) through our converter, `reader.GetString()` nthrew on the Number token. With `[ApiController]` commented out, ASP.NET swallowed the exception and delivered `scans = null`.

### 2. Missing `ReadAsPropertyName`/`WriteAsPropertyName` — `Dictionary<Id, T>` crash

After fixing `CanConvert`, the flow progressed but crashed during `ShiftScheduleTopic` checkpoint serialization. `Dictionary<Id, UserActivity>` requires `Id` to be serializable as a **JSON property name**, but `TypeConverterJsonConverter<T>` only overrode `Read`/`Write` — not `ReadAsPropertyName`/`WriteAsPropertyName`. STJ fell back to its default handler which can't construct `Id`.

## Changes

### `TypeConverterJsonConverterFactory.cs`

 - **Narrowed `CanConvert`** from a broad 3-check heuristic to `TypeDescriptor.GetConverter(typeToConvert) is TextConverter` — only matches Totem's custom types, not .NET built-ins
 - **Added `ReadAsPropertyName`** — delegates to `TypeConverter.ConvertFromInvariantString` for dictionary key deserialization
 - **Added `WriteAsPropertyName`** — delegates to `TypeConverter.ConvertToInvariantString` for dictionary key serialization

## Impact

Fixes serialization for all `TextConverter`-based types (`Id`, `TypeName`, `FileLink`, `HttpLink`, `MediaType`, `Sha1`, etc.) in both value and dictionary-key positions, without interfering with STJ's native handling of built-in types.