### PR TITLE
PR #7 - Bug: gRPC Deadline Not Applied to Batch Append Writes

### DIFF
--- a/src/Totem.Timeline.EventStore/EventStoreContext.cs
+++ b/src/Totem.Timeline.EventStore/EventStoreContext.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using EventStore.Client;
 using Totem.Runtime;
@@ -11,16 +12,18 @@ namespace Totem.Timeline.EventStore
   /// </summary>
   public class EventStoreContext : Connection
   {
-    public EventStoreContext(EventStoreClient client, IJsonFormat json, AreaMap area)
+    public EventStoreContext(EventStoreClient client, IJsonFormat json, AreaMap area, TimeSpan? deadline)
     {
       Client = client;
       Json = json;
       Area = area;
+      Deadline = deadline;
     }
 
     public readonly EventStoreClient Client;
     public readonly IJsonFormat Json;
     public readonly AreaMap Area;
+    public readonly TimeSpan? Deadline;
 
     protected override Task Open()
     {

--- a/src/Totem.Timeline.EventStore/EventStoreContextExtensions.cs
+++ b/src/Totem.Timeline.EventStore/EventStoreContextExtensions.cs
@@ -164,10 +164,10 @@ namespace Totem.Timeline.EventStore
     //
 
     static Task<IWriteResult> AppendEvent(this EventStoreContext context, string stream, EventData data) =>
-      context.Client.AppendToStreamAsync(stream, StreamState.Any, new[] { data });
+      context.Client.AppendToStreamAsync(stream, StreamState.Any, new[] { data }, deadline: context.Deadline);
 
     internal static Task<IWriteResult> AppendToTimeline(this EventStoreContext context, IEnumerable<EventData> data) =>
-      context.Client.AppendToStreamAsync(TimelineStreams.Timeline, StreamState.Any, data);
+      context.Client.AppendToStreamAsync(TimelineStreams.Timeline, StreamState.Any, data, deadline: context.Deadline);
 
     internal static Task<IWriteResult> AppendToTimeline(this EventStoreContext context, EventData data) =>
       context.AppendEvent(TimelineStreams.Timeline, data);
@@ -176,13 +176,13 @@ namespace Totem.Timeline.EventStore
       context.AppendEvent(flow.Context.Key.GetCheckpointStream(), context.GetCheckpointEventData(flow));
 
     internal static Task<IWriteResult> AppendToClient(this EventStoreContext context, Event e) =>
-      context.Client.AppendToStreamAsync(TimelineStreams.Client, StreamState.Any, new[] { context.GetClientEventData(e) });
+      context.Client.AppendToStreamAsync(TimelineStreams.Client, StreamState.Any, new[] { context.GetClientEventData(e) }, deadline: context.Deadline);
 
     //
     // Metadata
     //
 
     internal static Task<IWriteResult> SetCheckpointStreamMetadata(this EventStoreContext context, Flow flow, StreamMetadata value) =>
-      context.Client.SetStreamMetadataAsync(flow.Context.Key.GetCheckpointStream(), StreamState.Any, value);
+      context.Client.SetStreamMetadataAsync(flow.Context.Key.GetCheckpointStream(), StreamState.Any, value, deadline: context.Deadline);
   }
 }

--- a/src/Totem.Timeline.EventStore/Hosting/EventStoreClientServiceExtensions.cs
+++ b/src/Totem.Timeline.EventStore/Hosting/EventStoreClientServiceExtensions.cs
@@ -24,7 +24,8 @@ namespace Totem.Timeline.EventStore.Hosting
         .AddSingleton(p => new EventStoreContext(
           p.BuildClient(),
           p.GetRequiredService<IJsonFormat>(),
-          p.GetRequiredService<AreaMap>()))
+          p.GetRequiredService<AreaMap>(),
+          p.GetOptions<EventStoreTimelineOptions>().Connection.Timeout))
         .AddSingleton<IClientDb, ClientDb>()
         .AddSingleton<IQueryDb, QueryDb>());
 

--- a/src/Totem.Timeline.EventStore/Hosting/EventStoreServiceExtensions.cs
+++ b/src/Totem.Timeline.EventStore/Hosting/EventStoreServiceExtensions.cs
@@ -28,7 +28,8 @@ namespace Totem.Timeline.EventStore.Hosting
         services.AddSingleton(p => new EventStoreContext(
           p.BuildClient(),
           p.GetRequiredService<IJsonFormat>(),
-          p.GetRequiredService<AreaMap>()));
+          p.GetRequiredService<AreaMap>(),
+          p.GetOptions<EventStoreTimelineOptions>().Connection.Timeout));
 
         services.AddSingleton<IResumeProjection>(p => new ResumeProjection(
           p.GetRequiredService<AreaMap>(),


### PR DESCRIPTION
This is a known issue with ES client v23.x+; the DefaultDeadline is not propagated to the batch append API.

## Summary

Fixes a bug where the configured `connection.timeout` (15 minutes in `appsettings.json`) was silently ignored for all EventStore write operations, leaving them subject to the ESDB server's default ~10-second timeout. Under periods of I/O pressure this caused `Grpc.Core.RpcException: DeadlineExceeded` errors which permanently killed flows.

---

## Root Cause

`EventStore.Client.Grpc.Streams` v23.3.9 uses a `StreamAppender` (duplex streaming RPC) for all writes. Unlike single-call operations (reads, deletes, metadata), the batch append path **ignores `EventStoreClientSettings.DefaultDeadline`** — it only honours a `deadline` parameter passed directly to `AppendToStreamAsync`. Decompiled client source confirms this:

```csharp
// ✅  Non-batch path (reads, deletes) — falls back to DefaultDeadline
CreateNonStreaming(settings, deadline ?? settings.DefaultDeadline, ...)

// ❌  Batch append path (StreamAppender) — passes raw parameter, never consults DefaultDeadline
BatchAppender.Append(streamName, expectedState, eventData, deadline, cancellationToken)
```

Since Totem called `AppendToStreamAsync` without an explicit `deadline` argument (i.e., `deadline = null`), `StreamAppender` sent `DateTime.MaxValue` in the legacy `Deadline21100` protobuf field and left the newer `Deadline` (Duration) field unset. ESDB 24.10 reads the `Deadline` field, finds it absent, and falls back to its own server-side default — causing timeouts on writes that legitimately take longer than ~10 seconds under disk I/O pressure.

This was confirmed by correlating the stack traces across all three debug logs:

| Time | Event |
|------|-------|
| 17:56–02:03 | ESDB `StorageWriterQueue` logging `WritePrepares` at 1.5–5.4s (disk at 81% capacity) |
| 02:03:35 | `Quantum.Web` — `DeadlineExceeded` in `ClientDb.WriteEvent` during a command |
| 07:43:10 | ESDB forcibly closes the gRPC connection |
| 07:44:09 | `Quantum.Service` — SmartScanner flow lifetime ends with `DeadlineExceeded` at position #408039 |

---

## Fix

`EventStoreContext` is already the shared carrier threaded into every append call via `EventStoreContextExtensions`. The fix stores the configured `TimeSpan?` on the context at construction time and passes it explicitly on every `AppendToStreamAsync` / `SetStreamMetadataAsync` call.

### Modified Files

| File | Change |
|------|--------|
| `src/Totem.Timeline.EventStore/EventStoreContext.cs` | Added `public readonly TimeSpan? Deadline;` field and corresponding constructor parameter |
| `src/Totem.Timeline.EventStore/Hosting/EventStoreServiceExtensions.cs` | Passes `options.Connection.Timeout` when constructing `EventStoreContext` (service host) |
| `src/Totem.Timeline.EventStore/Hosting/EventStoreClientServiceExtensions.cs` | Passes `options.Connection.Timeout` when constructing `EventStoreContext` (web/client host) |
| `src/Totem.Timeline.EventStore/EventStoreContextExtensions.cs` | Passes `context.Deadline` on all 4 append calls and `SetStreamMetadataAsync` |

### No callers change

`TimelineDb`, `ClientDb`, and all `DbOperations` are untouched. The fix is entirely internal to the EventStore integration layer.

### `TimeSpan?` is kept nullable

`null` means "no explicit deadline — rely on server default", which preserves the existing behaviour for any environment that removes the timeout from config. When a value is set (as in both `appsettings.json` files: `"timeout": "00:15:00"`), it is now forwarded to every write.

---

## Before / After

```csharp
// Before — deadline = null, server applies its own ~10s default
context.Client.AppendToStreamAsync(TimelineStreams.Timeline, StreamState.Any, data);

// After — configured 15-minute timeout passed explicitly, bypassing DefaultDeadline omission
context.Client.AppendToStreamAsync(TimelineStreams.Timeline, StreamState.Any, data, deadline: context.Deadline);
```

---

## Testing

- `dotnet build src/Totem.Timeline.EventStore/Totem.Timeline.EventStore.csproj` — ✅ succeeded (4 pre-existing warnings in unrelated upstream assemblies)
- Integration tests require a locally configured EventStore process path (user secret) not available in this environment — no regressions were introduced to test infrastructure; all test failures are the same infrastructure error present on `dev`
